### PR TITLE
Automate SHyPi Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,66 +14,18 @@ This project is intended for monitoring and alerting on hydroponic grow data. It
 ## Parts List
 https://myhydropi.com/hydropi-parts-list
 - - - -
-## Getting Started (Software)
-### Prerequisites
-#### Install Dependencies
-```
-apt-get install -y apache2 php libapache2-mod-php ffmpeg imagemagick mariadb-server-10.0 php-mysql python-mysqldb i2c-tools
-```
-
-#### Configure File Permissions
-```
-mkdir /home/pi/SHyPi
-chown www-data:www-data /home/pi/SHyPi/
-chmod 777 /home/pi/SHyPi/
-```
-
-#### Create MySQL Configuration Script
-> /home/pi/SHyPi/mysql_secure_install.sql
-
-```
-CREATE DATABASE hydropi;
-USE hydropi;
-CREATE TABLE notes (dateandtime VARCHAR(30),notes VARCHAR(1500)); 
-CREATE TABLE grows (growid INT(11) NOT NULL AUTO_INCREMENT, startdate VARCHAR(12), enddate VARCHAR(12), strainname VARCHAR(25), growername VARCHAR(25), othernotes VARCHAR(1500), PRIMARY KEY (growid));
-GRANT ALL PRIVILEGES ON *.* TO 'serenityadmin'@'localhost' IDENTIFIED BY 'Serenity2019!';
-DELETE FROM mysql.user WHERE User='';
-DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
-DROP DATABASE IF EXISTS test;
-DELETE FROM mysql.db WHERE Db='test';
-FLUSH PRIVILEGES;
-```
-
-#### Execute MySQL Configuration Script
-```
-mysql -fu root < "/home/pi/SHyPi/mysql_secure_install.sql"
-```
-
-### Installing SHyPi software
-#### Clone the project source code to your RPi
+## Install SHyPi software
+### Clone the project source code to your Raspberry Pi
 ```
 git clone https://github.com/psycoder17/SHyPi.git /home/pi/SHyPi/src/
-cp -r /home/pi/SHyPi/src/html/* /var/www/html/
 ```
 
-#### Remove default Apache index page
+### Run `install.sh` script to automatically configure your RPi to run this project
 ```
-rm -rf /var/www/html/index.html
-```
-
-#### Configure File Permissions
-```
-chown www-data:www-data /var/www/html/timelapses/
-chmod 777 /var/www/html/timelapses/
+sudo bash /home/pi/SHyPi/src/install.sh
 ```
 
-#### Allow www-data user to reboot machine (from web console buttons)
-```
-chown www-data:www-data /var/www/html/php/restart.php
-echo "www-data	ALL=(root) NOPASSWD: /sbin/reboot, /sbin/poweroff" >> /etc/sudoers
-```
-
-#### Create cronjob to run monitoring script at boot
+### Create cronjob to run monitoring script at boot
 ```
 (sudo crontab -l 2>/dev/null; echo "@reboot python /home/pi/SHyPi/src/python2/Serenity-HydroPi.py") | sudo crontab -
 ```

--- a/html/processtimelapse.php
+++ b/html/processtimelapse.php
@@ -21,7 +21,7 @@ $final_enddate .= $enddate_array[1];
 $mkvidcmd = "ffmpeg -r 24 -pattern_type glob -i 'camimages/*.jpg' -vcodec libx264 -pix_fmt rgba /var/www/html/timelapses/".$filename.".mp4";
 system($mkvidcmd);
 
-$url = "Location: http://192.168.1.101/timelapses/".$filename.".mp4";
+$url = "Location: http://localhost/timelapses/".$filename.".mp4";
 header($url);
 die();
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#USAGE: sudo bash install.sh
+
+#Update package index
+apt-get update -y
+
+#Install dependencies with aptitude
+apt-get install -y apache2 php libapache2-mod-php ffmpeg imagemagick mariadb-server-10.0 php-mysql python-mysqldb i2c-tools
+
+#Configure permissions for project directory
+mkdir /home/pi/SHyPi
+chown www-data:www-data /home/pi/SHyPi/
+chmod 777 /home/pi/SHyPi/ #In a real-world scenario, 777 permissions can be risky, but as this dashboard is not meant to be internet facing the attack surface is greatly reduced
+
+#Generate mysql_secure_install.sql script
+echo -e "CREATE DATABASE hydropi;\nUSE hydropi;\nCREATE TABLE notes (dateandtime VARCHAR(30),notes VARCHAR(1500)); \nCREATE TABLE grows (growid INT(11) NOT NULL AUTO_INCREMENT, startdate VARCHAR(12), enddate VARCHAR(12), strainname VARCHAR(25), growername VARCHAR(25), othernotes VARCHAR(1500), PRIMARY KEY (growid));\nGRANT ALL PRIVILEGES ON *.* TO 'serenityadmin'@'localhost' IDENTIFIED BY 'Serenity2019!';\nDELETE FROM mysql.user WHERE User='';\nDELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');\nDROP DATABASE IF EXISTS test;\nDELETE FROM mysql.db WHERE Db='test';\nFLUSH PRIVILEGES;" > /home/pi/SHyPi/mysql_secure_install.sql
+
+#Execute MySQL configuration script
+mysql -fu root < "/home/pi/SHyPi/mysql_secure_install.sql"
+
+#Move web dashboard files to apache's www folder
+cp -r /home/pi/SHyPi/src/html/* /var/www/html/
+
+#Remove default Apache index page
+rm -rf /var/www/html/index.html
+
+#Configure permissions for folder that holds all the generated timelapse videos
+chown www-data:www-data /var/www/html/timelapses/
+chmod 777 /var/www/html/timelapses/
+
+#Allow www-data user to reboot machine (from web console buttons)
+chown www-data:www-data /var/www/html/php/restart.php
+echo "www-data	ALL=(root) NOPASSWD: /sbin/reboot, /sbin/poweroff" >> /etc/sudoers


### PR DESCRIPTION
Use a bash script to automate the installation of dependencies, configure the web dashboard, and set up permissions for folders used by this project. 